### PR TITLE
feat(match): add favorite driver info in activity match

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<plugin xmlns="http://www.phonegap.com/ns/plugins/1.0" 
-  xmlns:android="http://schemas.android.com/apk/res/android" 
-  xmlns:amazon="http://schemas.android.com/apk/lib/com.amazon.device.ads" 
-  xmlns:rim="http://www.blackberry.com/ns/widgets" 
+<plugin xmlns="http://www.phonegap.com/ns/plugins/1.0"
+  xmlns:android="http://schemas.android.com/apk/res/android"
+  xmlns:amazon="http://schemas.android.com/apk/lib/com.amazon.device.ads"
+  xmlns:rim="http://www.blackberry.com/ns/widgets"
   id="phonegap-plugin-push" version="2.3.0">
   <name>PushPlugin</name>
   <description>    This plugin allows your application to receive push notifications on Android, iOS and Windows devices.    Android uses Firebase Cloud Messaging.    iOS uses Apple APNS Notifications.    Windows uses Microsoft WNS Notifications.  </description>
@@ -103,6 +103,7 @@
     <source-file src="res/android/drawable/slide_thumb_animated.xml" target-dir="res/drawable/"/>
     <source-file src="res/android/drawable/slide_thumb.xml" target-dir="res/drawable/"/>
     <source-file src="res/android/drawable/yellow_badge.xml" target-dir="res/drawable/"/>
+    <source-file src="res/android/drawable/ic_round_star_24.xml" target-dir="res/drawable/"/>
     <source-file src="res/android/layout/activity_match.xml" target-dir="res/layout/"/>
     <source-file src="res/android/layout/activity_scheduled.xml" target-dir="res/layout/"/>
     <source-file src="res/android/values/match-attrs.xml" target-dir="res/values/"/>

--- a/res/android/drawable/ic_round_star_24.xml
+++ b/res/android/drawable/ic_round_star_24.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8"?>
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+  android:width="24dp"
+  android:height="24dp"
+  android:viewportWidth="24"
+  android:viewportHeight="24">
+
+  <path
+    android:name="rect883"
+    android:pathData="M 0 0 H 24 V 24 H 0 V 0 Z" />
+  <path
+    android:name="path885"
+    android:fillColor="#fff02b"
+    android:strokeColor="#000000"
+    android:strokeAlpha="0.76975947"
+    android:strokeWidth="1.78876686"
+    android:pathData="M 15.392901,8.6947725 13.356849,1.9910418 c -0.401666,-1.31581509 -2.25766,-1.31581509 -2.645479,0 L 8.6614684,8.6947725 h -6.163554 c -1.343516,0 -1.89754329,1.7313355 -0.8033394,2.5069745 l 5.0416485,3.601177 -1.9806477,6.385166 c -0.4016697,1.288114 1.0942038,2.326912 2.1607066,1.509723 l 5.1109016,-3.878191 5.110903,3.892042 c 1.066501,0.81719 2.562376,-0.22161 2.160707,-1.509725 l -1.980648,-6.385165 5.041649,-3.601177 c 1.094203,-0.789489 0.540176,-2.5069735 -0.803342,-2.5069735 h -6.163552 z" />
+</vector>

--- a/res/android/layout/activity_match.xml
+++ b/res/android/layout/activity_match.xml
@@ -134,35 +134,64 @@
       android:background="@drawable/gray_badge"
       android:paddingHorizontal="10dp"
       android:orientation="horizontal">
+
       <LinearLayout
-        android:layout_width="0dp"
-        android:layout_height="wrap_content"
-        android:layout_weight="0.5"
-        android:layout_marginRight="10dp"
-        android:layout_marginVertical="@dimen/default_spacing"
-        android:gravity="center"
+        android:id="@+id/favorite_driver_layout"
+        android:layout_width="45dp"
+        android:layout_height="85dp"
         android:layout_gravity="center"
+        android:layout_marginVertical="@dimen/default_spacing"
+        android:layout_marginRight="0dp"
+        android:layout_weight="0.1"
+        android:gravity="center"
         android:orientation="vertical">
+        <ImageView
+          android:layout_width="40dp"
+          android:layout_height="40dp"
+          android:src="@drawable/ic_round_star_24"/>
+        <TextView
+          android:layout_width="wrap_content"
+          android:layout_height="wrap_content"
+          android:layout_gravity="center_horizontal"
+          android:layout_marginTop="0dp"
+          android:text="Motorista Favorito"
+          android:textAlignment="center"
+          android:textColor="@color/colorPrimary"
+          android:textSize="13sp" />
+      </LinearLayout>
+
+      <LinearLayout
+        android:layout_width="93dp"
+        android:layout_height="wrap_content"
+        android:layout_gravity="center"
+        android:layout_marginVertical="@dimen/default_spacing"
+        android:layout_marginRight="10dp"
+        android:layout_weight="0.5"
+        android:gravity="center"
+        android:orientation="vertical">
+
         <TextView
           android:id="@+id/initial_value_text"
-          android:layout_width="match_parent"
+          android:layout_width="wrap_content"
           android:layout_height="wrap_content"
+          android:text="VALOR MÍNIMO"
           android:textColor="@color/darkGray"
-          android:textStyle="bold"
           android:textSize="14sp"
-          android:visibility="gone"
-          android:text="VALOR MÍNIMO"/>
+          android:textStyle="bold"
+          android:layout_gravity="center"
+          android:visibility="gone" />
+
         <TextView
           android:id="@+id/driver_commission_text"
           android:layout_width="wrap_content"
           android:layout_height="wrap_content"
-          android:textStyle="bold"
+          android:text="R$2000,78"
           android:textSize="28sp"
-          android:text="R$2000,78"/>
+          android:textStyle="bold" />
       </LinearLayout>
       <TextView
         android:id="@+id/layout_gray_divider"
-        android:layout_marginTop="-10dp"
+        android:layout_marginTop="0dp"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:textSize="80sp"
@@ -184,7 +213,7 @@
           android:layout_height="wrap_content"
           android:layout_gravity="center_vertical"
           android:textStyle="bold"
-          android:textSize="14sp"
+          android:textSize="12sp"
           android:text="+ KM EXCEDENTE AO MÍNIMO"/>
         <TextView
           android:id="@+id/driver_bonus_text"
@@ -193,7 +222,7 @@
           android:layout_height="wrap_content"
           android:layout_gravity="center_vertical"
           android:textStyle="bold"
-          android:textSize="14sp"
+          android:textSize="12sp"
           android:text="+ R$10,00 (BÔNUS)"/>
       </LinearLayout>
     </LinearLayout>

--- a/src/android/com/adobe/phonegap/push/PushConstants.java
+++ b/src/android/com/adobe/phonegap/push/PushConstants.java
@@ -119,6 +119,7 @@ public interface PushConstants {
   public static final String LOCATION_RADIUS = "radius";
   public static final String PING_NOTIFICATION = "isPing";
   public static final String USER_TOKEN = "userToken";
+  public static final String USER_ID = "userId";
   public static final String API_URL = "apiUrl";
   public static final String HAS_PERMISSION_SYSTEM_ALERT = "hasPermissionSystemAlert";
   public static final String REQUEST_PERMISSION_SYSTEM_ALERT = "requestPermissionSystemAlert";

--- a/src/android/com/adobe/phonegap/push/PushPlugin.java
+++ b/src/android/com/adobe/phonegap/push/PushPlugin.java
@@ -189,10 +189,12 @@ public class PushPlugin extends CordovaPlugin implements PushConstants {
           String token = null;
           String senderID = null;
           String userToken = null;
+          int userId = 0;
           String apiUrl = null;
 
           try {
             userToken = data.getJSONObject(0).has(USER_TOKEN) ? data.getJSONObject(0).getString(USER_TOKEN) : null;
+            userId = data.getJSONObject(0).has(USER_ID) ? data.getJSONObject(0).getInt(USER_ID) : null;
             apiUrl = data.getJSONObject(0).getString(API_URL);
             jo = data.getJSONObject(0).getJSONObject(ANDROID);
 
@@ -272,6 +274,7 @@ public class PushPlugin extends CordovaPlugin implements PushConstants {
             editor.putString(MESSAGE_KEY, jo.optString(MESSAGE_KEY));
             editor.putString(TITLE_KEY, jo.optString(TITLE_KEY));
             editor.putString(USER_TOKEN, userToken);
+            editor.putInt(USER_ID, userId);
             editor.putString(API_URL, apiUrl);
             editor.commit();
 
@@ -311,6 +314,7 @@ public class PushPlugin extends CordovaPlugin implements PushConstants {
               editor.remove(FORCE_SHOW);
               editor.remove(SENDER_ID);
               editor.remove(USER_TOKEN);
+              editor.remove(USER_ID);
               editor.commit();
             }
 

--- a/src/android/com/adobe/phonegap/push/match/MatchActivity.java
+++ b/src/android/com/adobe/phonegap/push/match/MatchActivity.java
@@ -25,6 +25,7 @@ import android.widget.LinearLayout;
 import android.widget.ProgressBar;
 import android.widget.TextView;
 import android.widget.Toast;
+import android.util.Log;
 
 import com.adobe.phonegap.push.PushConstants;
 import com.adobe.phonegap.push.PushHandlerActivity;
@@ -33,6 +34,7 @@ import com.android.volley.VolleyError;
 import com.google.android.gms.location.FusedLocationProviderClient;
 import com.google.android.gms.location.LocationServices;
 
+import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
 
@@ -49,6 +51,7 @@ import static android.support.v4.app.NotificationCompat.PRIORITY_MAX;
 
 public class MatchActivity extends Activity implements PushConstants {
   private static long DURATION = 30000;
+  public static final String LOG_TAG = "Push_Plugin";
   private CountDownTimer mCountDownTimer;
   private RejectedOrders mRejectedOrders = null;
   private BeeBeeApiService mBeeBeeApiService = null;
@@ -96,6 +99,7 @@ public class MatchActivity extends Activity implements PushConstants {
 
       SharedPreferences sharedPref = getApplicationContext().getSharedPreferences(COM_ADOBE_PHONEGAP_PUSH, Context.MODE_PRIVATE);
       final String userToken = sharedPref.getString(USER_TOKEN, "");
+      final int driverId = sharedPref.getInt(USER_ID, 0);
       final String apiUrl = sharedPref.getString(API_URL, "");
       mBeeBeeApiService = new BeeBeeApiService(this, orderId, userToken, apiUrl);
 
@@ -103,7 +107,7 @@ public class MatchActivity extends Activity implements PushConstants {
       mIsScheduled = mScheduleDate != null && !mScheduleDate.isEmpty() && !mScheduleDate.equalsIgnoreCase("null");
 
       setButtonEvents(orderId, uid);
-      setActivityValues(jsonOrder);
+      setActivityValues(jsonOrder, driverId);
       setActivityScheduledIfNeeded(jsonOrder);
 
     } catch (JSONException e) {
@@ -384,7 +388,7 @@ public class MatchActivity extends Activity implements PushConstants {
     view.setTypeface(font);
   }
 
-  private void setActivityValues(JSONObject jsonOrder) throws JSONException {
+  private void setActivityValues(JSONObject jsonOrder, int driverId) throws JSONException {
     SlideButton slideButton = findViewById(Meta.getResId(this, "id", "slide_button"));
     int colorAccent = ResourcesCompat.getColor(getResources(),
       Meta.getResId(this, "color", "colorAccent"), null);
@@ -399,6 +403,7 @@ public class MatchActivity extends Activity implements PushConstants {
     setItemValue("freight_type_text", jsonOrder.getString("freightType"));
     setItemValue("order_route_summary_text", jsonOrder.getString("routeSummary"));
     setItemValue("origin_text", jsonOrder.getString("address"));
+
 
     String destinationAddress = jsonOrder.getString("destinationAddress");
     String firstObservations = jsonOrder.getString("firstObservations");
@@ -423,6 +428,7 @@ public class MatchActivity extends Activity implements PushConstants {
     TextView initialValueText = findViewById(Meta.getResId(this, "id", "initial_value_text"));
     TextView totalValueText = findViewById(Meta.getResId(this, "id", "total_value_text"));
     LinearLayout layoutCostExtras = findViewById(Meta.getResId(this, "id", "layout_cost_extras"));
+    LinearLayout favoriteDriverLayout = findViewById(Meta.getResId(this, "id", "favorite_driver_layout"));
 
     driverBonusText.setVisibility(View.GONE);
     dynamicCostText.setVisibility(View.GONE);
@@ -430,7 +436,35 @@ public class MatchActivity extends Activity implements PushConstants {
     layoutCostExtras.setVisibility(View.GONE);
     initialValueText.setVisibility(View.GONE);
     totalValueText.setVisibility(View.GONE);
+    favoriteDriverLayout.setVisibility(View.GONE);
     setItemValue("order_type_text", "ROTA FIXA");
+
+    try {
+      JSONArray favoriteDriversFromCompany = jsonOrder.getJSONArray("requesterCompanyFavoriteDrivers");
+      boolean isFavoriteDriver = false;
+
+      Log.d(LOG_TAG, "Iniciando verificação de driver favorito");
+
+      Log.d(LOG_TAG, "DRIVER LOGADO: " + driverId);
+
+      for (int i = 0; i < favoriteDriversFromCompany.length(); i++) {
+        int id = favoriteDriversFromCompany.getJSONObject(i).getInt("id");
+        Log.d(LOG_TAG, "Comparando com id: " + id);
+        if (id == driverId) {
+          isFavoriteDriver = true;
+          break;
+        }
+      }
+
+      Log.d(LOG_TAG, "------------ IS FAVORITE DRIVER: " + isFavoriteDriver + " ----------------");
+
+      if (isFavoriteDriver) {
+        favoriteDriverLayout.setVisibility(View.VISIBLE);
+      }
+    } catch (JSONException e) {
+      Log.d(LOG_TAG, "------------ IS FAVORITE DRIVER: error on get ----------------");
+      Log.d(LOG_TAG, jsonOrder.toString());
+    }
 
     if (showDriverBonus) {
       setItemValue("driver_bonus_text", driverBonus);


### PR DESCRIPTION
## Do que se trata essa mudança?

* [x] - Nova(s) funcionalidade(s)
* [ ] - Correção de bug(s)
* [ ] - Documentação
* [ ] - Outros (especificar)

Adicionado informação de motorista favorito na tela de match

## Motorista Favorito

Foi criado um drawable de uma estrela para ser exibido quando um match acontecer e o motorista atual for favorito da empresa que solicitou o frete. A API está mandando os IDs dos motoristas favoritos dela, portanto é feito apenas uma comparação simples se o motorista que está recebendo o match de frete está inserido nos favoritos dela. Para isso acontecer o APP está mandando o ID do usuário logado também.

## Frameworks/Plugins/Libs utilizados

Nenhum

## Áreas impactadas

* Match (motorista favorito): a tela de match agora informa se o motorista for favorito.
* Init push service no app: agora para este comportamento ser visível o app deve enviar o `userId` no init do push service.

## Passos para reproduzir

1. Colocar o código dessa PR (Java e XML) nos respectivos arquivos da platform Android no aplicativo
2. Rodar num dispositivo ou emulador
3. Favoritar um motorista na plataforma antes de solicitar um frete
4. Solicitar um frete
5. Logar com o motorista favorito e verificar o match
6. Logar com um motorista não favorito e verificar se o frete aparece sem a estrela