### PR TITLE
fix: add again favorite driver in match

### DIFF
--- a/res/android/layout/activity_match.xml
+++ b/res/android/layout/activity_match.xml
@@ -101,14 +101,39 @@
       android:layout_below="@id/layout_header"
       android:layout_centerHorizontal="true"
       android:layout_marginLeft="@dimen/default_spacing"
-      android:layout_marginTop="@dimen/default_spacing"
       android:layout_marginRight="@dimen/default_spacing"
+      android:layout_marginTop="@dimen/default_spacing"
       android:background="@drawable/gray_badge"
-      android:orientation="horizontal"
-      android:paddingHorizontal="10dp">
+      android:paddingHorizontal="10dp"
+      android:orientation="horizontal">
 
       <LinearLayout
-        android:layout_width="0dp"
+        android:id="@+id/favorite_driver_layout"
+        android:layout_width="45dp"
+        android:layout_height="85dp"
+        android:layout_gravity="center"
+        android:layout_marginVertical="@dimen/default_spacing"
+        android:layout_marginRight="0dp"
+        android:layout_weight="0.1"
+        android:gravity="center"
+        android:orientation="vertical">
+        <ImageView
+          android:layout_width="40dp"
+          android:layout_height="40dp"
+          android:src="@drawable/ic_round_star_24"/>
+        <TextView
+          android:layout_width="wrap_content"
+          android:layout_height="wrap_content"
+          android:layout_gravity="center_horizontal"
+          android:layout_marginTop="0dp"
+          android:text="Motorista Favorito"
+          android:textAlignment="center"
+          android:textColor="@color/colorPrimary"
+          android:textSize="13sp" />
+      </LinearLayout>
+
+      <LinearLayout
+        android:layout_width="93dp"
         android:layout_height="wrap_content"
         android:layout_gravity="center"
         android:layout_marginVertical="@dimen/default_spacing"
@@ -119,12 +144,13 @@
 
         <TextView
           android:id="@+id/initial_value_text"
-          android:layout_width="match_parent"
+          android:layout_width="wrap_content"
           android:layout_height="wrap_content"
           android:text="VALOR MÍNIMO"
           android:textColor="@color/darkGray"
           android:textSize="14sp"
           android:textStyle="bold"
+          android:layout_gravity="center"
           android:visibility="gone" />
 
         <TextView
@@ -135,45 +161,41 @@
           android:textSize="28sp"
           android:textStyle="bold" />
       </LinearLayout>
-
       <TextView
         android:id="@+id/layout_gray_divider"
+        android:layout_marginTop="0dp"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:layout_marginTop="-10dp"
-        android:paddingBottom="5dp"
-        android:text="{"
+        android:textSize="80sp"
         android:textColor="@color/gray"
-        android:textSize="80sp" />
-
+        android:paddingBottom="5dp"
+        android:text="{"/>
       <LinearLayout
         android:id="@+id/layout_cost_extras"
         android:layout_width="0dp"
         android:layout_height="wrap_content"
-        android:layout_gravity="center_vertical"
-        android:layout_marginLeft="10dp"
         android:layout_weight="0.5"
+        android:layout_marginLeft="10dp"
+        android:layout_gravity="center_vertical"
         android:orientation="vertical">
-
         <TextView
           android:id="@+id/dynamic_cost_text"
+          android:layout_marginVertical="0dp"
           android:layout_width="wrap_content"
           android:layout_height="wrap_content"
           android:layout_gravity="center_vertical"
-          android:layout_marginVertical="5dp"
-          android:text="+ KM EXCEDENTE AO MÍNIMO"
-          android:textSize="14sp"
-          android:textStyle="bold" />
-
+          android:textStyle="bold"
+          android:textSize="12sp"
+          android:text="+ KM EXCEDENTE AO MÍNIMO"/>
         <TextView
           android:id="@+id/driver_bonus_text"
+          android:layout_marginVertical="0dp"
           android:layout_width="wrap_content"
           android:layout_height="wrap_content"
           android:layout_gravity="center_vertical"
-          android:layout_marginVertical="5dp"
-          android:text="+ R$10,00 (BÔNUS)"
-          android:textSize="14sp"
-          android:textStyle="bold" />
+          android:textStyle="bold"
+          android:textSize="12sp"
+          android:text="+ R$10,00 (BÔNUS)"/>
       </LinearLayout>
     </LinearLayout>
 

--- a/src/android/com/adobe/phonegap/push/match/MatchActivity.java
+++ b/src/android/com/adobe/phonegap/push/match/MatchActivity.java
@@ -26,6 +26,7 @@ import android.widget.LinearLayout;
 import android.widget.ProgressBar;
 import android.widget.TextView;
 import android.widget.Toast;
+import android.util.Log;
 
 import com.adobe.phonegap.push.PushConstants;
 import com.adobe.phonegap.push.PushHandlerActivity;
@@ -34,10 +35,10 @@ import com.android.volley.VolleyError;
 import com.google.android.gms.location.FusedLocationProviderClient;
 import com.google.android.gms.location.LocationServices;
 
+import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
 
-import java.io.IOException;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
 import java.util.Date;
@@ -51,6 +52,7 @@ import static android.support.v4.app.NotificationCompat.PRIORITY_MAX;
 
 public class MatchActivity extends Activity implements PushConstants {
   private static long DURATION = 30000;
+  public static final String LOG_TAG = "Push_Plugin";
   private CountDownTimer mCountDownTimer;
   private RejectedOrders mRejectedOrders = null;
   private BeeBeeApiService mBeeBeeApiService = null;
@@ -98,6 +100,7 @@ public class MatchActivity extends Activity implements PushConstants {
 
       SharedPreferences sharedPref = getApplicationContext().getSharedPreferences(COM_ADOBE_PHONEGAP_PUSH, Context.MODE_PRIVATE);
       final String userToken = sharedPref.getString(USER_TOKEN, "");
+      final int driverId = sharedPref.getInt(USER_ID, 0);
       final String apiUrl = sharedPref.getString(API_URL, "");
       mBeeBeeApiService = new BeeBeeApiService(this, orderId, userToken, apiUrl);
 
@@ -105,7 +108,7 @@ public class MatchActivity extends Activity implements PushConstants {
       mIsScheduled = mScheduleDate != null && !mScheduleDate.isEmpty() && !mScheduleDate.equalsIgnoreCase("null");
 
       setButtonEvents(orderId, uid);
-      setActivityValues(jsonOrder);
+      setActivityValues(jsonOrder, driverId);
       setActivityScheduledIfNeeded(jsonOrder);
 
     } catch (JSONException e) {
@@ -386,7 +389,7 @@ public class MatchActivity extends Activity implements PushConstants {
     view.setTypeface(font);
   }
 
-  private void setActivityValues(JSONObject jsonOrder) throws JSONException {
+  private void setActivityValues(JSONObject jsonOrder, int driverId) throws JSONException {
     SlideButton slideButton = findViewById(Meta.getResId(this, "id", "slide_button"));
     int colorAccent = ResourcesCompat.getColor(getResources(),
       Meta.getResId(this, "color", "colorAccent"), null);
@@ -427,6 +430,7 @@ public class MatchActivity extends Activity implements PushConstants {
     TextView initialValueText = findViewById(Meta.getResId(this, "id", "initial_value_text"));
     TextView totalValueText = findViewById(Meta.getResId(this, "id", "total_value_text"));
     LinearLayout layoutCostExtras = findViewById(Meta.getResId(this, "id", "layout_cost_extras"));
+    LinearLayout favoriteDriverLayout = findViewById(Meta.getResId(this, "id", "favorite_driver_layout"));
     ImageView mapPreview = findViewById(Meta.getResId(this, "id", "map_preview"));
 
     driverBonusText.setVisibility(View.GONE);
@@ -435,8 +439,36 @@ public class MatchActivity extends Activity implements PushConstants {
     layoutCostExtras.setVisibility(View.GONE);
     initialValueText.setVisibility(View.GONE);
     totalValueText.setVisibility(View.GONE);
+    favoriteDriverLayout.setVisibility(View.GONE);
     mapPreview.setVisibility(View.GONE);
     setItemValue("order_type_text", "ROTA FIXA");
+
+    try {
+      JSONArray favoriteDriversFromCompany = jsonOrder.getJSONArray("requesterCompanyFavoriteDrivers");
+      boolean isFavoriteDriver = false;
+
+      Log.d(LOG_TAG, "Iniciando verificação de driver favorito");
+
+      Log.d(LOG_TAG, "DRIVER LOGADO: " + driverId);
+
+      for (int i = 0; i < favoriteDriversFromCompany.length(); i++) {
+        int id = favoriteDriversFromCompany.getJSONObject(i).getInt("id");
+        Log.d(LOG_TAG, "Comparando com id: " + id);
+        if (id == driverId) {
+          isFavoriteDriver = true;
+          break;
+        }
+      }
+
+      Log.d(LOG_TAG, "------------ IS FAVORITE DRIVER: " + isFavoriteDriver + " ----------------");
+
+      if (isFavoriteDriver) {
+        favoriteDriverLayout.setVisibility(View.VISIBLE);
+      }
+    } catch (JSONException e) {
+      Log.d(LOG_TAG, "------------ IS FAVORITE DRIVER: error on get ----------------");
+      Log.d(LOG_TAG, jsonOrder.toString());
+    }
 
     if (showDriverBonus) {
       setItemValue("driver_bonus_text", driverBonus);


### PR DESCRIPTION
Novamente adicionando a funcionalidade de motorista favorito, pois quando foi criada essa branch acabou se perdendo.

## Do que se trata essa mudança?

* [x] - Nova(s) funcionalidade(s)
* [ ] - Correção de bug(s)
* [ ] - Documentação
* [ ] - Outros (especificar)

Adicionado informação de motorista favorito na tela de match

## Motorista Favorito

Foi criado um drawable de uma estrela para ser exibido quando um match acontecer e o motorista atual for favorito da empresa que solicitou o frete. A API está mandando os IDs dos motoristas favoritos dela, portanto é feito apenas uma comparação simples se o motorista que está recebendo o match de frete está inserido nos favoritos dela. Para isso acontecer o APP está mandando o ID do usuário logado também.

## Frameworks/Plugins/Libs utilizados

Nenhum

## Áreas impactadas

* Match (motorista favorito): a tela de match agora informa se o motorista for favorito.
* Init push service no app: agora para este comportamento ser visível o app deve enviar o `userId` no init do push service.

## Passos para reproduzir

1. Colocar o código dessa PR (Java e XML) nos respectivos arquivos da platform Android no aplicativo
2. Rodar num dispositivo ou emulador
3. Favoritar um motorista na plataforma antes de solicitar um frete
4. Solicitar um frete
5. Logar com o motorista favorito e verificar o match
6. Logar com um motorista não favorito e verificar se o frete aparece sem a estrela