### PR TITLE
Feat: Add MiUI app permissions check

### DIFF
--- a/src/android/com/adobe/phonegap/push/PushConstants.java
+++ b/src/android/com/adobe/phonegap/push/PushConstants.java
@@ -123,6 +123,9 @@ public interface PushConstants {
   public static final String API_URL = "apiUrl";
   public static final String HAS_PERMISSION_SYSTEM_ALERT = "hasPermissionSystemAlert";
   public static final String REQUEST_PERMISSION_SYSTEM_ALERT = "requestPermissionSystemAlert";
+  public static final String HAS_PERMISSION_MIUI = "hasPermissionMiUI";
+  public static final String REQUEST_PERMISSION_MIUI = "requestPermissionMiUI";
   public static final int ANDROID_VERSION_MARSHMALLOW = 23;
   public static final int REQUEST_SYSTEM_ALERT_WINDOW = 1;
+  public static final int REQUEST_MIUI_PERMISSIONS = 2;
 }

--- a/src/js/push.js
+++ b/src/js/push.js
@@ -331,6 +331,14 @@ module.exports = {
     exec(successCallback, errorCallback, 'PushNotification', 'requestPermissionSystemAlert', []);
   },
 
+  hasPermissionMiUI: (successCallback, errorCallback) {
+    exec(successCallback, errorCallback, 'PushNotification', 'hasPermissionMiUI', []);
+  },
+
+  requestPermissionMiUI: (successCallback, errorCallback) {
+    exec(successCallback, errorCallback, 'PushNotification', 'requestPermissionMiUI', []);
+  },
+
   createChannel: (successCallback, errorCallback, channel) => {
     exec(successCallback, errorCallback, 'PushNotification', 'createChannel', [channel]);
   },

--- a/www/push.js
+++ b/www/push.js
@@ -372,6 +372,14 @@ module.exports = {
     exec(successCallback, errorCallback, 'PushNotification', 'requestPermissionSystemAlert', []);
   },
 
+  hasPermissionMiUI: function hasPermissionMiUI(successCallback, errorCallback) {
+    exec(successCallback, errorCallback, 'PushNotification', 'hasPermissionMiUI', []);
+  },
+
+  requestPermissionMiUI: function requestPermissionMiUI(successCallback, errorCallback) {
+    exec(successCallback, errorCallback, 'PushNotification', 'requestPermissionMiUI', []);
+  },
+
   createChannel: function createChannel(successCallback, errorCallback, channel) {
     exec(successCallback, errorCallback, 'PushNotification', 'createChannel', [channel]);
   },


### PR DESCRIPTION
## Do que se trata essa mudança?

* [x] - Nova(s) funcionalidade(s)
* [x] - Correção de bug(s)
* [ ] - Documentação
* [ ] - Outros (especificar)

Verificação das permissões de extras da MiUI

## Add MiUI app permissions check

A interface MiUI tem mais duas permissões além da sobreposição da _overlay permission_, que na MiUI se refere a _Exibir janelas pop-up_, padrão do Android:

- Mostrar na Tela de bloqueio;
- Mostrar janelas pop-up enquanto estiver executando em segundo plano;

Ainda não foi divulgada uma forma de verificar os estado dessas duas permissões, então somente foi implementada métodos para verificar se a interface é MiUI e para abrir a janela de _Outras permissões_ do app que a chamar.

## Áreas impactadas

* src/android/com/adobe/phonegap/push/PushConstants.java
* src/android/com/adobe/phonegap/push/PushPlugin.java
* src/js/push.js
* www/push.js

## Passos para reproduzir

Em um aparelho que possui a MiUI, siga os passos

1. Colocar o código dessa PR (Java e XML) nos respectivos arquivos da platform Android no aplicativo
2. Rodar num dispositivo com MiUI
3. Fazer login com usuário motorista
4. Deixar o aplicativo em background e com a tela bloqueada
4. Em outro aparelho, fazer um pedido de frete numa região próxima do motorista
5. Verificar se é recebido a notificação de frete