### PR TITLE
Versao 2.7.0

### DIFF
--- a/src/android/com/adobe/phonegap/push/PushConstants.java
+++ b/src/android/com/adobe/phonegap/push/PushConstants.java
@@ -123,6 +123,9 @@ public interface PushConstants {
   public static final String API_URL = "apiUrl";
   public static final String HAS_PERMISSION_SYSTEM_ALERT = "hasPermissionSystemAlert";
   public static final String REQUEST_PERMISSION_SYSTEM_ALERT = "requestPermissionSystemAlert";
+  public static final String HAS_PERMISSION_MIUI = "hasPermissionMiUI";
+  public static final String REQUEST_PERMISSION_MIUI = "requestPermissionMiUI";
   public static final int ANDROID_VERSION_MARSHMALLOW = 23;
   public static final int REQUEST_SYSTEM_ALERT_WINDOW = 1;
+  public static final int REQUEST_MIUI_PERMISSIONS = 2;
 }

--- a/src/android/com/adobe/phonegap/push/PushPlugin.java
+++ b/src/android/com/adobe/phonegap/push/PushPlugin.java
@@ -16,6 +16,8 @@ import android.os.Bundle;
 import android.provider.Settings;
 import android.support.v4.app.NotificationCompat;
 import android.support.v4.app.NotificationManagerCompat;
+
+import android.text.TextUtils;
 import android.util.Log;
 
 import com.google.firebase.iid.FirebaseInstanceId;
@@ -30,7 +32,9 @@ import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
 
+import java.io.BufferedReader;
 import java.io.IOException;
+import java.io.InputStreamReader;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.Iterator;

--- a/src/android/com/adobe/phonegap/push/match/BeeBeeApiService.java
+++ b/src/android/com/adobe/phonegap/push/match/BeeBeeApiService.java
@@ -6,6 +6,7 @@ import android.os.Build;
 import android.util.Log;
 
 import com.android.volley.AuthFailureError;
+import com.android.volley.DefaultRetryPolicy;
 import com.android.volley.NetworkResponse;
 import com.android.volley.Request;
 import com.android.volley.RequestQueue;
@@ -25,6 +26,7 @@ import java.security.KeyManagementException;
 import java.security.NoSuchAlgorithmException;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.concurrent.TimeUnit;
 
 import javax.net.ssl.SSLSocket;
 import javax.net.ssl.SSLSocketFactory;
@@ -113,6 +115,12 @@ public class BeeBeeApiService {
         return params;
       }
     };
+
+    jsObjRequest.setRetryPolicy(new DefaultRetryPolicy(
+      (int) TimeUnit.SECONDS.toMillis(30),
+      0,
+      DefaultRetryPolicy.DEFAULT_BACKOFF_MULT
+    ));
 
     mQueue.add(jsObjRequest);
   }

--- a/src/js/push.js
+++ b/src/js/push.js
@@ -331,6 +331,14 @@ module.exports = {
     exec(successCallback, errorCallback, 'PushNotification', 'requestPermissionSystemAlert', []);
   },
 
+  hasPermissionMiUI: (successCallback, errorCallback) {
+    exec(successCallback, errorCallback, 'PushNotification', 'hasPermissionMiUI', []);
+  },
+
+  requestPermissionMiUI: (successCallback, errorCallback) {
+    exec(successCallback, errorCallback, 'PushNotification', 'requestPermissionMiUI', []);
+  },
+
   createChannel: (successCallback, errorCallback, channel) => {
     exec(successCallback, errorCallback, 'PushNotification', 'createChannel', [channel]);
   },

--- a/www/push.js
+++ b/www/push.js
@@ -372,6 +372,14 @@ module.exports = {
     exec(successCallback, errorCallback, 'PushNotification', 'requestPermissionSystemAlert', []);
   },
 
+  hasPermissionMiUI: function hasPermissionMiUI(successCallback, errorCallback) {
+    exec(successCallback, errorCallback, 'PushNotification', 'hasPermissionMiUI', []);
+  },
+
+  requestPermissionMiUI: function requestPermissionMiUI(successCallback, errorCallback) {
+    exec(successCallback, errorCallback, 'PushNotification', 'requestPermissionMiUI', []);
+  },
+
   createChannel: function createChannel(successCallback, errorCallback, channel) {
     exec(successCallback, errorCallback, 'PushNotification', 'createChannel', [channel]);
   },


### PR DESCRIPTION
## Do que se trata essa mudança?

* [ ] - Nova(s) funcionalidade(s)
* [x] - Correção de bug(s)
* [ ] - Documentação
* [ ] - Outros (especificar)

Redefinição do retry no aceite do pedido e correções de fluxo.

## Match accept retry

- Foi redefinido o retry do volley para não tentar refazer a requisição em caso de timeout.
- Foi adicionado comportamento padrão de sair da tela de match em caso de erro mesmo não clicando no botão "ok" no dialog informativo do erro.
- Foi adicionado comportamento de não exibir novamente um match caso já tenha sido aceito.

## Frameworks/Plugins/Libs utilizados

Nenhum.

## Áreas impactadas

ActivityMatch:

* aceite do pedido

## Passos para reproduzir

1. copie os arquivos alterados para a platforms do aplicativo
2. rode localmente ou apontando para dev
3. simule dois pushes
4. simule timeout