### PR TITLE
feat(clear-rejected): rejected orders may be cleared

### DIFF
--- a/src/android/com/adobe/phonegap/push/PushConstants.java
+++ b/src/android/com/adobe/phonegap/push/PushConstants.java
@@ -15,6 +15,7 @@ public interface PushConstants {
   public static final String SOUND_RINGTONE = "ringtone";
   public static final String VIBRATE = "vibrate";
   public static final String ACTIONS = "actions";
+  public static final String ACTION = "action";
   public static final String CALLBACK = "callback";
   public static final String ACTION_CALLBACK = "actionCallback";
   public static final String DRAWABLE = "drawable";

--- a/src/android/com/adobe/phonegap/push/match/MatchActivity.java
+++ b/src/android/com/adobe/phonegap/push/match/MatchActivity.java
@@ -15,8 +15,8 @@ import android.os.Build;
 import android.os.Bundle;
 import android.os.CountDownTimer;
 import android.os.Vibrator;
-import androidx.core.app.NotificationCompat;
-import androidx.core.content.res.ResourcesCompat;
+import android.support.v4.app.NotificationCompat;
+import android.support.v4.content.res.ResourcesCompat;
 import android.text.Html;
 import android.text.Spanned;
 import android.view.View;
@@ -45,7 +45,7 @@ import java.text.SimpleDateFormat;
 import java.util.Date;
 import java.util.Random;
 
-import static androidx.core.app.NotificationCompat.PRIORITY_MAX;
+import static android.support.v4.app.NotificationCompat.PRIORITY_MAX;
 
 /**
  * Created by alvaro.menezes on 05/12/2017.

--- a/src/android/com/adobe/phonegap/push/match/MatchActivity.java
+++ b/src/android/com/adobe/phonegap/push/match/MatchActivity.java
@@ -15,8 +15,8 @@ import android.os.Build;
 import android.os.Bundle;
 import android.os.CountDownTimer;
 import android.os.Vibrator;
-import android.support.v4.app.NotificationCompat;
-import android.support.v4.content.res.ResourcesCompat;
+import androidx.core.app.NotificationCompat;
+import androidx.core.content.res.ResourcesCompat;
 import android.text.Html;
 import android.text.Spanned;
 import android.view.View;
@@ -45,7 +45,7 @@ import java.text.SimpleDateFormat;
 import java.util.Date;
 import java.util.Random;
 
-import static android.support.v4.app.NotificationCompat.PRIORITY_MAX;
+import static androidx.core.app.NotificationCompat.PRIORITY_MAX;
 
 /**
  * Created by alvaro.menezes on 05/12/2017.
@@ -90,11 +90,15 @@ public class MatchActivity extends Activity implements PushConstants {
     mExtras = getIntent().getBundleExtra(NOTIFICATION_EXTRAS);
 
     try {
+      String action = mExtras.getString(ACTION);
       JSONObject jsonOrder = new JSONObject(mExtras.getString(MATCH_ORDER_DETAILS));
       final int orderId = jsonOrder.getInt("id");
       final String uid = jsonOrder.getString("uid");
-
+      
       if (mRejectedOrders.exists(uid)) {
+        if(action.equals("ORDER_CLEAR")){
+          mRejectedOrders.remove(uid);
+        }
         finish();
         return;
       }

--- a/src/android/com/adobe/phonegap/push/match/RejectedOrders.java
+++ b/src/android/com/adobe/phonegap/push/match/RejectedOrders.java
@@ -42,6 +42,18 @@ public class RejectedOrders {
     prefsEditor.apply();
   }
 
+  public void remove(String uid){
+    SharedPreferences prefs = mActivity.getPreferences(Context.MODE_PRIVATE);
+    SharedPreferences.Editor prefsEditor = prefs.edit();
+
+    String strRejectedOrders = prefs.getString(REJECTED_ORDERS, null);
+    ArrayList<String> rejectedOrders = new ArrayList<String>(Arrays.asList(strRejectedOrders.split(",")));
+    rejectedOrders.remove(uid);
+
+    prefsEditor.putString(REJECTED_ORDERS, TextUtils.join(",", rejectedOrders));
+    prefsEditor.apply();
+  }
+
   public boolean exists(String poolDateId){
     SharedPreferences prefs = mActivity.getPreferences(Context.MODE_PRIVATE);
 


### PR DESCRIPTION
## Feat(clear-rejected)

* [x] - Nova(s) funcionalidade(s)
* [ ] - Correção de bug(s)
* [ ] - Documentação
* [ ] - Outros (especificar)

é possível limpar pedido rejeitado

## “Limpa pedido rejeitado”

Quando admin limpa rejeite de um motorista, api envia requisição para limpar rejeite de entregador 

## Áreas impactadas

* **RejectedOrders** tem função de remoção agora

## Passos para reproduzir

1. Ter um pedido em Pool
2. Rejeitar o Pedido
3. Admin deve limpar individualmente rejeite de entregador

## TODO: Pós-merged

1. Mobile deve apontar para versão 2.8